### PR TITLE
Fix `KT-48273`

### DIFF
--- a/markdown-frontend/build.gradle.kts
+++ b/markdown-frontend/build.gradle.kts
@@ -1,8 +1,17 @@
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+
 plugins { kotlin(Plugins.KotlinJs) }
 
 repositories {
   jcenter()
   mavenCentral()
+}
+
+// FIXME : Remove once KT-48273 is fixed
+afterEvaluate {
+  rootProject.extensions.configure<NodeJsRootExtension> {
+    versions.webpackDevServer.version = "4.0.0"
+  }
 }
 
 dependencies {


### PR DESCRIPTION
A recent update to the Webpack dev server broke all Kotlin/JS builds (see https://youtrack.jetbrains.com/issue/KT-48273). This commit temporarily fixes it by specifying an explicit version for the dev server.
